### PR TITLE
Add the Elastic Beanstalk CLI tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk -v --update add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.11.188 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.11.188 s3cmd==2.0.1 python-magic awsebcli && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*
 VOLUME /root/.aws


### PR DESCRIPTION
I'd like to propose adding the Elastic Beanstalk CLI tool in addition to the main AWS tool. This allows this to be used for other types of AWS deployments.

Thoughts?